### PR TITLE
Add option to left-align images on Boundless stories using built-in images block with captions

### DIFF
--- a/dev/nau-block-custom_cta/nau-block-custom_cta.css
+++ b/dev/nau-block-custom_cta/nau-block-custom_cta.css
@@ -140,6 +140,15 @@ div.nau-block-custom_cta.left-align {
     color: var(--accent-color);
 }
 
+:is(figure.um-custom-left-image, #important) {
+    float: left;
+    margin-left: -13em;
+    margin-right: 2.5em;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    width: 90%;
+    max-width: 750px;
+}
 
 @media (max-width: 991px) {
     .nau-block-custom_cta article.content-wrapper .breakout-col {
@@ -166,5 +175,13 @@ div.nau-block-custom_cta.left-align {
         width: 100% !important;
         max-width: 95vw !important;
         float: unset !important;
+    }
+    
+    :is(figure.um-custom-left-image, #important) {
+        float: unset;
+        margin-left: auto;
+        margin-right: auto;
+        width: 100%;
+        max-width: unset;
     }
 }


### PR DESCRIPTION
Hey @djm653 just a minor change allowing us to left-align images on Boundless stories that also have the Q&A/CTA block. This style change works with the existing block, so it's easy to implement on the backend. If you approve, I can enable it for the forensics debate story that's currently being published.

Please review and approve or deny at your earliest convenience. I know Cecile wants to get this one up, so I'll be moving forward without it unless I hear more from you.

Thanks so much!

## Demo images

### Before
<img width="1548" alt="Screen Shot 2022-08-18 at 3 24 18 PM" src="https://user-images.githubusercontent.com/66445285/185505840-2dba2627-ec08-4a50-9817-bebeab13d65e.png">

### After
<img width="1548" alt="Screen Shot 2022-08-18 at 3 24 26 PM" src="https://user-images.githubusercontent.com/66445285/185505846-23c75f37-8e89-415a-9355-024880c0d603.png">

